### PR TITLE
refactor: response dto, request dto를 controller layer로 이동

### DIFF
--- a/src/main/kotlin/com/template/auth/controller/AuthApiController.kt
+++ b/src/main/kotlin/com/template/auth/controller/AuthApiController.kt
@@ -1,9 +1,9 @@
 package com.template.auth.controller
 
-import com.template.auth.dto.AccessTokenUpdateRequestDto
-import com.template.auth.dto.AccessTokenUpdateResponseDto
-import com.template.auth.dto.LoginRequestDto
-import com.template.auth.dto.LoginResponseDto
+import com.template.auth.controller.request.AccessTokenUpdateRequest
+import com.template.auth.controller.request.LoginRequest
+import com.template.auth.controller.response.AccessTokenUpdateResponse
+import com.template.auth.controller.response.LoginResponse
 import com.template.auth.service.AuthService
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -16,12 +16,14 @@ class AuthApiController(
 ) {
 
     @PostMapping("/v1/auth/update-token")
-    fun updateAccessToken(@Valid @RequestBody requestDto: AccessTokenUpdateRequestDto): AccessTokenUpdateResponseDto {
-        return authService.updateAccessToken(requestDto)
+    fun updateAccessToken(@Valid @RequestBody request: AccessTokenUpdateRequest): AccessTokenUpdateResponse {
+        return AccessTokenUpdateResponse(authService.updateAccessToken(request.refreshToken))
     }
 
     @PostMapping("/v1/auth/login")
-    fun login(@Valid @RequestBody requestDto: LoginRequestDto): LoginResponseDto {
-        return authService.login(requestDto)
+    fun login(@Valid @RequestBody request: LoginRequest): LoginResponse {
+        val (email, password) = request
+        val result = authService.login(email, password)
+        return LoginResponse(result.first, result.second)
     }
 }

--- a/src/main/kotlin/com/template/auth/controller/request/AccessTokenUpdateRequest.kt
+++ b/src/main/kotlin/com/template/auth/controller/request/AccessTokenUpdateRequest.kt
@@ -1,0 +1,8 @@
+package com.template.auth.controller.request
+
+import javax.validation.constraints.NotBlank
+
+data class AccessTokenUpdateRequest(
+    @field:NotBlank(message = "refreshToken is required.")
+    val refreshToken: String = "",
+)

--- a/src/main/kotlin/com/template/auth/controller/request/LoginRequest.kt
+++ b/src/main/kotlin/com/template/auth/controller/request/LoginRequest.kt
@@ -1,0 +1,16 @@
+package com.template.auth.controller.request
+
+import javax.validation.constraints.Email
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
+
+data class LoginRequest(
+    @field:Email
+    @field:NotBlank(message = "Email is required.")
+    var email: String = "",
+
+    @field:NotBlank(message = "Password is required.")
+    @field:Size(min = 5, max = 72)
+    var password: String = ""
+)
+

--- a/src/main/kotlin/com/template/auth/controller/response/AccessTokenUpdateResponse.kt
+++ b/src/main/kotlin/com/template/auth/controller/response/AccessTokenUpdateResponse.kt
@@ -1,0 +1,5 @@
+package com.template.auth.controller.response
+
+data class AccessTokenUpdateResponse(
+    val accessToken: String = ""
+)

--- a/src/main/kotlin/com/template/auth/controller/response/LoginResponse.kt
+++ b/src/main/kotlin/com/template/auth/controller/response/LoginResponse.kt
@@ -1,0 +1,6 @@
+package com.template.auth.controller.response
+
+data class LoginResponse(
+    val accessToken: String = "",
+    val refreshToken: String = ""
+)

--- a/src/main/kotlin/com/template/auth/dto/AccessTokenUpdateRequestDto.kt
+++ b/src/main/kotlin/com/template/auth/dto/AccessTokenUpdateRequestDto.kt
@@ -1,5 +1,0 @@
-package com.template.auth.dto
-
-data class AccessTokenUpdateRequestDto(
-    val refreshToken: String = ""
-)

--- a/src/main/kotlin/com/template/auth/dto/AccessTokenUpdateResponseDto.kt
+++ b/src/main/kotlin/com/template/auth/dto/AccessTokenUpdateResponseDto.kt
@@ -1,5 +1,0 @@
-package com.template.auth.dto
-
-data class AccessTokenUpdateResponseDto(
-    val accessToken: String = ""
-)

--- a/src/main/kotlin/com/template/auth/dto/LoginRequestDto.kt
+++ b/src/main/kotlin/com/template/auth/dto/LoginRequestDto.kt
@@ -1,15 +1,6 @@
 package com.template.auth.dto
 
-import javax.validation.constraints.Email
-import javax.validation.constraints.NotBlank
-import javax.validation.constraints.Size
-
 data class LoginRequestDto(
-    @field:Email
-    @field:NotBlank(message = "Email is required.")
     var email: String = "",
-
-    @field:NotBlank(message = "Password is required.")
-    @field:Size(min = 5, max = 72)
     var password: String = ""
 )

--- a/src/main/kotlin/com/template/auth/dto/LoginRequestDto.kt
+++ b/src/main/kotlin/com/template/auth/dto/LoginRequestDto.kt
@@ -1,6 +1,0 @@
-package com.template.auth.dto
-
-data class LoginRequestDto(
-    var email: String = "",
-    var password: String = ""
-)

--- a/src/main/kotlin/com/template/auth/dto/LoginResponseDto.kt
+++ b/src/main/kotlin/com/template/auth/dto/LoginResponseDto.kt
@@ -1,6 +1,0 @@
-package com.template.auth.dto
-
-data class LoginResponseDto(
-    val accessToken: String = "",
-    val refreshToken: String = ""
-)

--- a/src/main/kotlin/com/template/user/controller/UserApiController.kt
+++ b/src/main/kotlin/com/template/user/controller/UserApiController.kt
@@ -1,6 +1,7 @@
 package com.template.user.controller
 
 import com.template.config.annotation.LoggedInUser
+import com.template.user.controller.response.UserInfoResponse
 import com.template.user.dto.UserDto
 import com.template.user.service.UserService
 import org.springframework.web.bind.annotation.GetMapping
@@ -14,5 +15,5 @@ class UserApiController(
 ) {
 
     @GetMapping
-    fun getUserInfo(@LoggedInUser user: UserDto) = userService.getUserInfo(user)
+    fun getUserInfo(@LoggedInUser user: UserDto) = UserInfoResponse.from(userService.getUserInfo(user))
 }

--- a/src/main/kotlin/com/template/user/controller/response/UserInfoResponse.kt
+++ b/src/main/kotlin/com/template/user/controller/response/UserInfoResponse.kt
@@ -1,0 +1,13 @@
+package com.template.user.controller.response
+
+import com.template.user.dto.UserDto
+
+data class UserInfoResponse(
+    val id: Int,
+    val name: String,
+    val email: String
+) {
+    companion object {
+        fun from(userDto: UserDto) = UserInfoResponse(userDto.id, userDto.name, userDto.email)
+    }
+}

--- a/src/main/kotlin/com/template/user/dto/UserDto.kt
+++ b/src/main/kotlin/com/template/user/dto/UserDto.kt
@@ -9,6 +9,4 @@ data class UserDto(
     val email: String
 ) {
     constructor(user: User) : this(user.id!!, user.name, user.password!!, user.email)
-
-    fun toResponseDto() = UserInfoResponseDto(this.id, this.name, this.email)
 }

--- a/src/main/kotlin/com/template/user/dto/UserInfoResponseDto.kt
+++ b/src/main/kotlin/com/template/user/dto/UserInfoResponseDto.kt
@@ -1,7 +1,0 @@
-package com.template.user.dto
-
-data class UserInfoResponseDto(
-    val id: Int,
-    val name: String,
-    val email: String
-)

--- a/src/main/kotlin/com/template/user/service/UserService.kt
+++ b/src/main/kotlin/com/template/user/service/UserService.kt
@@ -9,5 +9,5 @@ class UserService(
     private val userRepository: UserRepository
 ) {
 
-    fun getUserInfo(userDto: UserDto) = userDto.toResponseDto()
+    fun getUserInfo(userDto: UserDto) = userDto
 }

--- a/src/test/kotlin/com/template/integration/auth/AccessTokenUpdateTest.kt
+++ b/src/test/kotlin/com/template/integration/auth/AccessTokenUpdateTest.kt
@@ -1,7 +1,7 @@
 package com.template.integration.auth
 
 import com.jayway.jsonpath.JsonPath
-import com.template.auth.dto.AccessTokenUpdateRequestDto
+import com.template.auth.controller.request.AccessTokenUpdateRequest
 import com.template.integration.ApiIntegrationTest
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
@@ -24,10 +24,10 @@ class AccessTokenUpdateTest : ApiIntegrationTest() {
     @Value("\${jwt.secret}")
     lateinit var secretKey: String
 
-    private fun apiCall(requestDto: AccessTokenUpdateRequestDto): ResultActionsDsl {
+    private fun apiCall(request: AccessTokenUpdateRequest): ResultActionsDsl {
         return mockMvc.post(URI.create("/v1/auth/update-token")) {
             contentType = MediaType.APPLICATION_JSON
-            content = objectMapper.writeValueAsString(requestDto)
+            content = objectMapper.writeValueAsString(request)
         }
     }
 
@@ -35,7 +35,7 @@ class AccessTokenUpdateTest : ApiIntegrationTest() {
     @Test
     fun updateToken_responseIsOkIfAllConditionsAreRight() {
         val userId = getUserId()
-        val requestDto = AccessTokenUpdateRequestDto(jwtTokenUtil.generateRefreshToken(userId))
+        val requestDto = AccessTokenUpdateRequest(jwtTokenUtil.generateRefreshToken(userId))
 
         val result = apiCall(requestDto).andExpect {
             status { isOk() }
@@ -49,7 +49,7 @@ class AccessTokenUpdateTest : ApiIntegrationTest() {
     @DisplayName("실패 - 토큰이 잘못된 경우")
     @Test
     fun updateToken_responseIsUnAuthorizedIfRefreshTokenIsMalformed() {
-        val requestDto = AccessTokenUpdateRequestDto(WRONG_TOKEN)
+        val requestDto = AccessTokenUpdateRequest(WRONG_TOKEN)
         apiCall(requestDto).andExpect {
             status { isUnauthorized() }
             assertErrorResponse(this, "잘못된 형식의 Jwt 토큰입니다.")
@@ -59,7 +59,7 @@ class AccessTokenUpdateTest : ApiIntegrationTest() {
     @DisplayName("실패 - 잘못된 userId")
     @Test
     fun updateToken_responseIsUnAuthorizedIfUserIdIsInvalid() {
-        val requestDto = AccessTokenUpdateRequestDto(jwtTokenUtil.generateRefreshToken(-1))
+        val requestDto = AccessTokenUpdateRequest(jwtTokenUtil.generateRefreshToken(-1))
         apiCall(requestDto).andExpect {
             status { isUnauthorized() }
             assertErrorResponse(this, "Unauthorized User Id.")
@@ -70,7 +70,7 @@ class AccessTokenUpdateTest : ApiIntegrationTest() {
     @Test
     fun updateToken_responseIsUnAuthorizedIfAccessTokenIsExpired() {
         val userId = getUserId()
-        val requestDto = AccessTokenUpdateRequestDto(generateExpiredRefreshToken(userId))
+        val requestDto = AccessTokenUpdateRequest(generateExpiredRefreshToken(userId))
         apiCall(requestDto).andExpect {
             status { isUnauthorized() }
             assertErrorResponse(this, "Jwt 토큰이 만료되었습니다.")

--- a/src/test/kotlin/com/template/integration/auth/LoginTest.kt
+++ b/src/test/kotlin/com/template/integration/auth/LoginTest.kt
@@ -1,7 +1,7 @@
 package com.template.integration.auth
 
 import com.jayway.jsonpath.JsonPath
-import com.template.auth.dto.LoginRequestDto
+import com.template.auth.controller.request.LoginRequest
 import com.template.integration.ApiIntegrationTest
 import com.template.util.EMAIL
 import com.template.util.PASSWORD
@@ -20,17 +20,10 @@ class LoginTest : ApiIntegrationTest() {
         const val WRONG_PASSWORD = "wrongPassword"
     }
 
-    private fun getLoginRequestDto(email: String, password: String): LoginRequestDto {
-        val requestDto = LoginRequestDto()
-        requestDto.email = email
-        requestDto.password = password
-        return requestDto
-    }
-
-    private fun apiCall(requestDto: LoginRequestDto): ResultActionsDsl {
+    private fun apiCall(request: LoginRequest): ResultActionsDsl {
         return mockMvc.post(URI.create("/v1/auth/login")) {
             contentType = MediaType.APPLICATION_JSON
-            content = objectMapper.writeValueAsString(requestDto)
+            content = objectMapper.writeValueAsString(request)
         }
     }
 
@@ -38,9 +31,9 @@ class LoginTest : ApiIntegrationTest() {
     @DisplayName("로그인 성공")
     fun login_responseIsOkIfAllConditionsAreRight() {
         val userId = getUserId()
-        val requestDto = getLoginRequestDto(EMAIL, PASSWORD)
+        val request = LoginRequest(EMAIL, PASSWORD)
 
-        val result = apiCall(requestDto).andExpect {
+        val result = apiCall(request).andExpect {
             status { isOk() }
             jsonPath("accessToken") { exists() }
             jsonPath("refreshToken") { exists() }
@@ -56,9 +49,9 @@ class LoginTest : ApiIntegrationTest() {
     @Test
     @DisplayName("로그인 실패 - 없는 이메일")
     fun login_responseIsNotFoundIfEmailIsWrong() {
-        val requestDto = getLoginRequestDto(WRONG_EMAIL, PASSWORD)
+        val request = LoginRequest(WRONG_EMAIL, PASSWORD)
 
-        apiCall(requestDto).andExpect {
+        apiCall(request).andExpect {
             status { isNotFound() }
             assertErrorResponse(this, "이메일 또는 비밀번호가 잘못되었습니다.")
         }
@@ -67,8 +60,8 @@ class LoginTest : ApiIntegrationTest() {
     @Test
     @DisplayName("로그인 실패 - 비밀번호 오류")
     fun login_responseIsNotFoundIfPasswordIsWrong() {
-        val requestDto = getLoginRequestDto(EMAIL, WRONG_PASSWORD)
-        apiCall(requestDto).andExpect {
+        val request = LoginRequest(EMAIL, WRONG_PASSWORD)
+        apiCall(request).andExpect {
             status { isNotFound() }
             assertErrorResponse(this, "이메일 또는 비밀번호가 잘못되었습니다.")
         }

--- a/src/test/kotlin/com/template/unit/auth/AccessTokenUpdateServiceUnitTest.kt
+++ b/src/test/kotlin/com/template/unit/auth/AccessTokenUpdateServiceUnitTest.kt
@@ -1,7 +1,6 @@
 package com.template.unit.auth
 
 import com.ninjasquad.springmockk.MockkBean
-import com.template.auth.dto.AccessTokenUpdateRequestDto
 import com.template.auth.exception.AuthenticateException
 import com.template.auth.service.AuthService
 import com.template.auth.tools.JwtTokenUtil
@@ -39,26 +38,26 @@ class AccessTokenUpdateServiceUnitTest : BaseUnitTest() {
     @Test
     fun updateAccessToken_Success() {
         every { userRepository.existsById(any()) } returns true
-        val requestDto = AccessTokenUpdateRequestDto(jwtTokenUtil.generateRefreshToken(USER_ID))
-        val result = authService.updateAccessToken(requestDto)
-        jwtTokenUtil.isTokenExpired(result.accessToken) shouldBe false
+        val refreshToken = jwtTokenUtil.generateRefreshToken(USER_ID)
+        val result = authService.updateAccessToken(refreshToken)
+        jwtTokenUtil.isTokenExpired(result) shouldBe false
     }
 
     @DisplayName("AccessToken 갱신 실패 - 잘못된 userId인 경우")
     @Test
     fun updateAccessToken_FailWrongUserId() {
         every { userRepository.existsById(any()) } returns false
-        val requestDto = AccessTokenUpdateRequestDto(jwtTokenUtil.generateRefreshToken(USER_ID))
-        val exception = assertThrows <AuthenticateException> { authService.updateAccessToken(requestDto) }
+        val refreshToken = jwtTokenUtil.generateRefreshToken(USER_ID)
+        val exception = assertThrows <AuthenticateException> { authService.updateAccessToken(refreshToken) }
         exception.message shouldBe "Unauthorized User Id."
     }
 
     @DisplayName("AccessToken 갱신 실패 - 만료된 refreshToken이 주어진 경우")
     @Test
     fun updateAccessToken_FailIfExpiredRefreshToken() {
-        val requestDto = AccessTokenUpdateRequestDto(jwtTokenUtil.generateRefreshToken(USER_ID))
+        val refreshToken = jwtTokenUtil.generateRefreshToken(USER_ID)
         every { jwtTokenUtil.isTokenExpired(any()) } returns true
-        val exception = shouldThrow<AuthenticateException> { authService.updateAccessToken(requestDto) }
+        val exception = shouldThrow<AuthenticateException> { authService.updateAccessToken(refreshToken) }
         exception.message shouldBe "RefreshToken has been expired."
     }
 }

--- a/src/test/kotlin/com/template/unit/auth/LoginUnitTest.kt
+++ b/src/test/kotlin/com/template/unit/auth/LoginUnitTest.kt
@@ -2,7 +2,6 @@ package com.template.unit.auth
 
 import com.ninjasquad.springmockk.MockkBean
 import com.ninjasquad.springmockk.SpykBean
-import com.template.auth.dto.LoginRequestDto
 import com.template.auth.exception.LoginException
 import com.template.auth.service.AuthService
 import com.template.auth.tools.JwtTokenUtil
@@ -43,10 +42,9 @@ class LoginUnitTest : BaseUnitTest() {
         user.id = USER_ID
         every { userRepository.findByEmail(any()) } returns Optional.of(user)
         every { encoder.matches(any(), any()) } returns true
-        val requestDto = LoginRequestDto(EMAIL, PASSWORD)
-        val responseDto = authService.login(requestDto)
-        jwtTokenUtil.isTokenExpired(responseDto.accessToken) shouldBe false
-        jwtTokenUtil.isTokenExpired(responseDto.refreshToken) shouldBe false
+        val result = authService.login(EMAIL, PASSWORD)
+        jwtTokenUtil.isTokenExpired(result.first) shouldBe false
+        jwtTokenUtil.isTokenExpired(result.second) shouldBe false
     }
 
     @DisplayName("로그인 실패 - 비밀번호 불일치")
@@ -54,8 +52,7 @@ class LoginUnitTest : BaseUnitTest() {
     fun login_FailIfWrongPassword() {
         every { encoder.matches(any(), any()) } returns false
         every { userRepository.findByEmail(any()) } returns Optional.of(getMockUser())
-        val requestDto = LoginRequestDto(EMAIL, PASSWORD)
-        val exception = shouldThrow<LoginException> { authService.login(requestDto) }
+        val exception = shouldThrow<LoginException> { authService.login(EMAIL, PASSWORD) }
         exception.message shouldBe "이메일 또는 비밀번호가 잘못되었습니다."
     }
 
@@ -63,8 +60,7 @@ class LoginUnitTest : BaseUnitTest() {
     @Test
     fun login_FailIfWrongEmail() {
         every { userRepository.findByEmail(any()) } returns Optional.empty()
-        val requestDto = LoginRequestDto(EMAIL, PASSWORD)
-        val exception = shouldThrow<LoginException> { authService.login(requestDto) }
+        val exception = shouldThrow<LoginException> { authService.login(EMAIL, PASSWORD) }
         exception.message shouldBe "이메일 또는 비밀번호가 잘못되었습니다."
     }
 }


### PR DESCRIPTION
- request dto, response dto는 service-domain layer로 사용되어야 하지, controller layer에서 직접적으로 사용하지 않도록 했다.
