### PR TITLE
fix: RequestRejectedHandler bean 추가

### DIFF
--- a/src/main/kotlin/com/template/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/template/security/config/SecurityConfig.kt
@@ -12,6 +12,8 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.config.web.servlet.invoke
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.security.web.firewall.HttpStatusRequestRejectedHandler
+import org.springframework.security.web.firewall.RequestRejectedHandler
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
@@ -64,5 +66,10 @@ class SecurityConfig(private val jwtTokenUtil: JwtTokenUtil, private val authent
         val source = UrlBasedCorsConfigurationSource()
         source.registerCorsConfiguration("/**", configuration)
         return source
+    }
+
+    @Bean
+    fun httpStatusRequestRejectedHandler(): RequestRejectedHandler {
+        return HttpStatusRequestRejectedHandler()
     }
 }


### PR DESCRIPTION
- `example.com//`, `example.com/..//` 등 잘못된 path에 대한 처리를 400으로 해준다.
- 이 Spring bean을 추가하지 않으면 500이 반환된다.

